### PR TITLE
Fix missing & concat operator

### DIFF
--- a/Model/EmployeeLdap.php
+++ b/Model/EmployeeLdap.php
@@ -247,7 +247,7 @@ class EmployeeLdap extends CakeLdapAppModel {
 		}
 
 		if (empty($conditions) || !is_array($conditions)) {
-			return $baseQuery;
+			return '(&' . $baseQuery . ')';
 		}
 
 		$result = '(&' . $baseQuery;


### PR DESCRIPTION
When there are no conditions passed to base query in `EmployeeLdap`.

Guess this was overseen as having no conditions is usually not the case.